### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "go"
+run = "go run main.go"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # LibraryManagement
+[![Run on Repl.it](https://repl.it/badge/github/santakdalai90/LibraryManagement)](https://repl.it/github/santakdalai90/LibraryManagement)
 Library management web app based on Iris Web Framework


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).